### PR TITLE
Fixes test by re-ordering the pipeline.

### DIFF
--- a/HeaderManip/Program.cs
+++ b/HeaderManip/Program.cs
@@ -38,8 +38,6 @@
     {
         public void Configuration(IAppBuilder app)
         {
-            app.UseMyMiddleware();
-
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationMode = AuthenticationMode.Active,
@@ -48,6 +46,8 @@
                 SlidingExpiration = true,
                 AuthenticationType = "MyCookie",
             });
+            
+            app.UseMyMiddleware();
 
             app.UseNancy();
 


### PR DESCRIPTION
OnSendingHeaders subscribers are executed in the order they are attached. UseCookieAuthentication attaches first so it get's to do it's header manipulation ("Set-Cookie") first, then your MW OnSendingHeaders hook gets invoked seeing those changes.
